### PR TITLE
Add comprehensive linting and PHPStan analysis setup

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,27 @@
+name: Review
+
+on: [pull_request]
+
+env:
+  TARGET_DRUPAL_CORE_VERSION: 11
+
+jobs:
+  drupal-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Lint Drupal
+      run: |
+        docker compose --profile lint run drupal-lint
+
+  drupal-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check Drupal compatibility
+      run: |
+        docker compose --profile lint run drupal-check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  drupal-lint:
+    image: ${COMPOSER_IMAGE:-composer:2.7}
+    profiles: ["lint"]
+    working_dir: /src
+    command: bash -c "./scripts/run-drupal-lint.sh"
+    environment:
+      TARGET_DRUPAL_CORE_VERSION: ${TARGET_DRUPAL_CORE_VERSION:-11}
+    volumes:
+      - .:/src
+
+  drupal-lint-auto-fix:
+    image: ${COMPOSER_IMAGE:-composer:2.7}
+    profiles: ["lint"]
+    working_dir: /src
+    command: bash -c "./scripts/run-drupal-lint-auto-fix.sh"
+    environment:
+      TARGET_DRUPAL_CORE_VERSION: ${TARGET_DRUPAL_CORE_VERSION:-11}
+    volumes:
+      - .:/src
+
+  drupal-check:
+    image: composer:2.7
+    profiles: ["lint"]
+    working_dir: /
+    command: bash -c "/src/scripts/run-drupal-check.sh"
+    tty: true
+    volumes:
+      - .:/src

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="views_color_scales">
+  <description>Default PHP CodeSniffer configuration for views_color_scales.</description>
+  <file>.</file>
+  <exclude-pattern>./vendor/*</exclude-pattern>
+  <exclude-pattern>./node_modules/*</exclude-pattern>
+  <exclude-pattern>./.git/*</exclude-pattern>
+  <exclude-pattern>./.github/*</exclude-pattern>
+
+  <rule ref="Drupal"/>
+  <rule ref="DrupalPractice"/>
+
+  <rule ref="PHPCompatibility">
+    <config name="testVersion" value="8.3-"/>
+  </rule>
+
+  <rule ref="Drupal.Commenting.DocComment.MissingShort">
+    <severity>0</severity>
+  </rule>
+
+  <rule ref="Drupal.Commenting.ClassComment.Missing">
+    <severity>0</severity>
+  </rule>
+</ruleset>

--- a/scripts/prepare-drupal-lint.sh
+++ b/scripts/prepare-drupal-lint.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Common stuff among php drupal linters.
+
+# Check if php is available
+php --version
+
+# Check if composer is available
+composer --version
+
+# Set target Drupal core version environment variable
+if [ -z "$TARGET_DRUPAL_CORE_VERSION" ]; then
+  TARGET_DRUPAL_CORE_VERSION=11
+fi
+
+echo "TARGET_DRUPAL_CORE_VERSION: $TARGET_DRUPAL_CORE_VERSION"
+
+# Set up Composer home directory
+export COMPOSER_HOME=/tmp
+cd /tmp
+
+# Create composer.json
+cat > composer.json << EOF
+{
+    "require-dev": {
+        "drupal/coder": "*",
+        "phpcompatibility/php-compatibility": "*",
+        "dealerdirect/phpcodesniffer-composer-installer": "*"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
+}
+EOF
+
+# Install coding standards tools
+composer update
+
+# Show installed packages
+composer show --installed
+
+# Check available coding standards
+./vendor/bin/phpcs -i
+
+# Configure PHPCS
+./vendor/bin/phpcs --config-set colors 1
+./vendor/bin/phpcs --config-set drupal_core_version ${TARGET_DRUPAL_CORE_VERSION}${TARGET_DRUPAL_CORE_VERSION}0
+
+# Show final config
+./vendor/bin/phpcs --config-show

--- a/scripts/run-drupal-check.sh
+++ b/scripts/run-drupal-check.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -vo pipefail
+
+# Install required libs for Drupal
+GD_ENABLED=$(php -i | grep 'GD Support' | awk '{ print $4 }')
+
+if [ "$GD_ENABLED" != 'enabled' ]; then
+  apk update && \
+  apk add libpng libpng-dev libjpeg-turbo-dev libwebp-dev zlib-dev libxpm-dev gd tree rsync && docker-php-ext-install gd
+fi
+
+# Create project in a temporary directory inside the container
+INSTALL_DIR="/drupal_install_tmp"
+composer create-project drupal/recommended-project:11.x-dev "$INSTALL_DIR" --no-interaction --stability=dev
+
+cd "$INSTALL_DIR"
+
+# Allow specific plugins needed by dependencies before requiring them.
+composer config --no-plugins allow-plugins.tbachert/spi true --no-interaction
+
+# Create phpstan.neon config file
+cat <<EOF > phpstan.neon
+parameters:
+    paths:
+        - web/modules/contrib/views_color_scales
+    # Set the analysis level (0-9)
+    level: 5
+EOF
+
+mkdir -p web/modules/contrib/
+
+if [ ! -L "web/modules/contrib/views_color_scales" ]; then
+  ln -s /src web/modules/contrib/views_color_scales
+fi
+
+# Install the statistics module if D11 (removed from core).
+composer require drupal/statistics --no-interaction
+
+# Install PHPStan extensions for Drupal 11 and Drush for command analysis
+composer require --dev phpstan/phpstan mglaman/phpstan-drupal phpstan/phpstan-deprecation-rules drush/drush --with-all-dependencies --no-interaction
+
+# Run phpstan
+./vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan.neon

--- a/scripts/run-drupal-lint-auto-fix.sh
+++ b/scripts/run-drupal-lint-auto-fix.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source scripts/prepare-drupal-lint.sh
+
+# Auto-fix Drupal coding standards
+echo "Auto-fixing Drupal coding standards..."
+./vendor/bin/phpcbf --standard=Drupal \
+  --extensions=php,module,inc,install,test,profile,theme,info,txt,md,yml \
+  --ignore="node_modules,vendor,.github" \
+  .
+
+# Auto-fix Drupal best practices
+echo "Auto-fixing Drupal best practices..."
+./vendor/bin/phpcbf --standard=DrupalPractice \
+  --extensions=php,module,inc,install,test,profile,theme,info,txt,md,yml \
+  --ignore="node_modules,vendor,.github" \
+  .

--- a/scripts/run-drupal-lint.sh
+++ b/scripts/run-drupal-lint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+source scripts/prepare-drupal-lint.sh
+
+EXIT_CODE=0
+
+# Check PHP Compatibility for PHP 8.3+
+echo "Checking PHP Compatibility (PHP 8.3+)..."
+./vendor/bin/phpcs --standard=PHPCompatibility \
+  --runtime-set testVersion 8.3- \
+  --extensions=php,module,inc,install,test,profile,theme \
+  --ignore="node_modules,vendor,.github" \
+  -v \
+  .
+
+status=$?
+if [ $status -ne 0 ]; then
+  EXIT_CODE=$status
+fi
+
+# Check Drupal coding standards
+echo "Checking Drupal coding standards..."
+./vendor/bin/phpcs --standard=Drupal \
+  --extensions=php,module,inc,install,test,profile,theme,info,txt,md,yml \
+  --ignore="node_modules,vendor,.github" \
+  -v \
+  .
+
+status=$?
+if [ $status -ne 0 ]; then
+  EXIT_CODE=$status
+fi
+
+# Check Drupal best practices
+echo "Checking Drupal best practices..."
+./vendor/bin/phpcs --standard=DrupalPractice \
+  --extensions=php,module,inc,install,test,profile,theme,info,txt,md,yml \
+  --ignore="node_modules,vendor,.github" \
+  -v \
+  .
+
+status=$?
+if [ $status -ne 0 ]; then
+  EXIT_CODE=$status
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

- Add complete Docker-based linting infrastructure matching dxpr_theme_helper approach
- Implement direct PHPStan usage with inline phpstan.neon configuration (level 5)
- Add Drupal coding standards and best practices linting
- Include GitHub Actions workflow for PR reviews  
- Use same PHPStan extensions: phpstan/phpstan, mglaman/phpstan-drupal, phpstan/phpstan-deprecation-rules
- Support Drupal 11.x with statistics module requirement
- Add phpcs.xml configuration for consistent code standards

## Test plan

- [x] Verify PHPStan analysis runs with new configuration
- [x] Confirm all linting scripts work correctly
- [x] Test Docker compose integration
- [x] Validate GitHub Actions workflow

This brings views_color_scales in line with the standardized linting approach across DXPR modules, adding the complete infrastructure that was missing from the main branch.

🤖 Generated with [Claude Code](https://claude.ai/code)